### PR TITLE
'use strict' for node v4

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const babelTemplate = require('babel-template')
 
 const buildHelper = babelTemplate(`


### PR DESCRIPTION
this simple commit is for node v4 compatibility

> Module build failed: SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode